### PR TITLE
Fix php 7x0 crash

### DIFF
--- a/php_win32service.h
+++ b/php_win32service.h
@@ -25,10 +25,14 @@
 extern zend_module_entry win32service_module_entry;
 #define phpext_win32service_ptr	&win32service_module_entry
 
-#define PHP_WIN32SERVICE_VERSION "0.1.2-RC1"
+#define PHP_WIN32SERVICE_VERSION "0.1.2-RC2"
 
 #ifndef PHP_WIN32
 # error This extension is for win32 only
+#endif
+
+#if PHP_MAJOR_VERSION < 7
+# error This extension is for PHP 7+ only
 #endif
 
 #ifndef SERVICE_WIN32_OWN_PROCESS_INTERACTIVE

--- a/win32service.c
+++ b/win32service.c
@@ -635,7 +635,7 @@ static PHP_MINIT_FUNCTION(win32service)
 		return FAILURE;
 	}
 	
-	if (PHP_MAJOR_VERSION <7 || (PHP_MAJOR_VERSION == 7 && (PHP_MINOR_VERSION == 0 || PHP_MINOR_VERSION == 1) && PHP_RELEASE_VERSION == 0) {
+	if (PHP_MAJOR_VERSION <7 || (PHP_MAJOR_VERSION == 7 && (PHP_MINOR_VERSION == 0 || PHP_MINOR_VERSION == 1) && PHP_RELEASE_VERSION == 0)) {
 		zend_error(E_CORE_ERROR, "The Win32Service extension not work on PHP 7.0.0 and 7.1.0. Work with 7.0.1+ or 7.1.1+");
 		return FAILURE;
 	}

--- a/win32service.c
+++ b/win32service.c
@@ -634,6 +634,11 @@ static PHP_MINIT_FUNCTION(win32service)
 		zend_error(E_CORE_WARNING, "The Win32Service extension is only available when using the CLI SAPI");
 		return FAILURE;
 	}
+	
+	if (PHP_MAJOR_VERSION <7 || (PHP_MAJOR_VERSION == 7 && (PHP_MINOR_VERSION == 0 || PHP_MINOR_VERSION == 1) && PHP_RELEASE_VERSION == 0) {
+		zend_error(E_CORE_ERROR, "The Win32Service extension not work on PHP 7.0.0 and 7.1.0. Work with 7.0.1+ or 7.1.1+");
+		return FAILURE;
+	}
 
 	ZEND_INIT_MODULE_GLOBALS(win32service, init_globals, NULL);
 

--- a/win32service.c
+++ b/win32service.c
@@ -635,8 +635,14 @@ static PHP_MINIT_FUNCTION(win32service)
 		return FAILURE;
 	}
 	
-	if (PHP_MAJOR_VERSION <7 || (PHP_MAJOR_VERSION == 7 && (PHP_MINOR_VERSION == 0 || PHP_MINOR_VERSION == 1) && PHP_RELEASE_VERSION == 0)) {
-		zend_error(E_CORE_ERROR, "The Win32Service extension not work on PHP 7.0.0 and 7.1.0. Work with 7.0.1+ or 7.1.1+");
+	if (PHP_MAJOR_VERSION == 7 && (PHP_MINOR_VERSION == 0 || PHP_MINOR_VERSION == 1) && PHP_RELEASE_VERSION == 0) {
+#if PHP_MINOR_VERSION == 0
+		zend_error(E_CORE_ERROR, "The Win32Service extension not work on PHP 7.0.0. Work with 7.0.1+");
+#elif PHP_MINOR_VERSION == 1
+		zend_error(E_CORE_ERROR, "The Win32Service extension not work on PHP 7.1.0. Work with 7.1.1+");
+#else
+		zend_error(E_CORE_ERROR, "The Win32Service extension not work with this PHP version");
+#endif
 		return FAILURE;
 	}
 


### PR DESCRIPTION
* add error message if extension is loaded into PHP 7.0.0 or PHP 7.1.0.
* add an condition for build this extension if PHP major version is less than 7