### PR TITLE
Update build script

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,5 +27,5 @@ build_script:
 
 artifacts:
   - path: artifacts
-    name: php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-vc14
+    name: php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%
     type: zip

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ version: '{branch}.{build}'
 
 cache:
   - c:\build-cache
-  - c:\build-cache\sdk -> .appveyor.yml
+  - c:\build-cache\sdk
 
 environment:
   SDK_REMOTE: https://github.com/OSTC/php-sdk-binary-tools.git

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
   matrix:
     - PHP_REL: 7.0
-      ARCHITECTURES: amd64 x86
+      ARCHITECTURES: x64 x86
       ZTS_STATES: enable disable
     - PHP_REL: 7.1
       ARCHITECTURES: x64 x86

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,13 +1,22 @@
 image: Visual Studio 2015
 version: '{branch}.{build}'
 
+cache:
+  - c:\build-cache
+  - c:\build-cache\sdk -> .appveyor.yml
+
 environment:
+  SDK_REMOTE: https://github.com/OSTC/php-sdk-binary-tools.git
+  SDK_BRANCH: php-sdk-2.0.0beta1
+  SDK_CACHE: c:\build-cache\sdk
+  CACHE_ROOT: c:\build-cache
+
   matrix:
 #    - PHP_REL: 7.0
 #      ARCHITECTURES: amd64 x86
 #      ZTS_STATES: enable disable
     - PHP_REL: 7.1
-      ARCHITECTURES: amd64
+      ARCHITECTURES: x64
       ZTS_STATES: enable
 
 install:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,8 +20,7 @@ environment:
       ZTS_STATES: enable disable
 
 install:
-- cmd: cinst wget
-- cmd: mkdir C:\projects\win32service\build
+  - appveyor\install.cmd
 
 build_script:
   - appveyor\build.cmd

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2015
 version: '{branch}.{build}'
 
 cache:
-  - c:\build-cache -> .appveyor.yml
+  - c:\build-cache
   - c:\build-cache\sdk -> .appveyor.yml
 
 environment:
@@ -12,9 +12,9 @@ environment:
   CACHE_ROOT: c:\build-cache
 
   matrix:
-#    - PHP_REL: 7.0
-#      ARCHITECTURES: amd64 x86
-#      ZTS_STATES: enable disable
+    - PHP_REL: 7.0
+      ARCHITECTURES: amd64 x86
+      ZTS_STATES: enable disable
     - PHP_REL: 7.1
       ARCHITECTURES: x64 x86
       ZTS_STATES: enable disable

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,8 +16,8 @@ environment:
 #      ARCHITECTURES: amd64 x86
 #      ZTS_STATES: enable disable
     - PHP_REL: 7.1
-      ARCHITECTURES: x64
-      ZTS_STATES: enable
+      ARCHITECTURES: x64 x86
+      ZTS_STATES: enable disable
 
 install:
 - cmd: cinst wget

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ image: Visual Studio 2015
 version: '{branch}.{build}'
 
 cache:
-  - c:\build-cache
+  - c:\build-cache -> .appveyor.yml
   - c:\build-cache\sdk -> .appveyor.yml
 
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,12 @@ version: '{branch}.{build}'
 
 environment:
   matrix:
-    - PHP_REL: 7.0
-      ARCHITECTURES: amd64 x86
-      ZTS_STATES: enable disable
+#    - PHP_REL: 7.0
+#      ARCHITECTURES: amd64 x86
+#      ZTS_STATES: enable disable
     - PHP_REL: 7.1
-      ARCHITECTURES: amd64 x86
-      ZTS_STATES: enable disable
+      ARCHITECTURES: amd64
+      ZTS_STATES: enable
 
 install:
 - cmd: cinst wget

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -2,16 +2,17 @@
 setlocal enableextensions enabledelayedexpansion
 	if not exist "%SDK_CACHE%" (
 		echo Cloning remote SDK repository
-		git clone --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%" 2>&1
+		echo git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
+		git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
 	) else (
 		echo Fetching remote SDK repository
-		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin 2>&1
+		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin
 		echo Checkout SDK repository branch
 		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" checkout --force %SDK_BRANCH%
 	)
 
 	echo git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
-	git clone --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
+	git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
 
 	xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\win32service\ /s /e /y /f
 
@@ -35,41 +36,8 @@ setlocal enableextensions enabledelayedexpansion
 			exit /b 3
 		)
 
-		call !SDK_RUNNER!
+		call !SDK_RUNNER! -t %APPVEYOR_BUILD_FOLDER%\appveyor\build_task.cmd
 
-		cd %APPVEYOR_BUILD_FOLDER%\appveyor
-		wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
-		7z x -y deps-%PHP_REL%-vc14-!DEPTS_ARCH!.7z -o%CACHE_ROOT%
-
-		for %%z in (%ZTS_STATES%) do (
-			set ZTS_STATE=%%z
-			if "!ZTS_STATE!"=="enable" set ZTS_SHORT=ts
-			if "!ZTS_STATE!"=="disable" set ZTS_SHORT=nts
-
-			cd C:\projects\php-src
-
-			call buildconf.bat
-
-			if %errorlevel% neq 0 exit /b 3
-
-			call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%CACHE_ROOT%\deps
-
-			if %errorlevel% neq 0 exit /b 3
-
-			nmake
-
-			if %errorlevel% neq 0 exit /b 3
-
-			nmake install
-
-			if %errorlevel% neq 0 exit /b 3
-
-			cd %APPVEYOR_BUILD_FOLDER%
-
-			if not exist build\ext\php_win32service.dll exit /b 3
-
-			move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-!DEPTS_ARCH!.dll
-		)
 	)
 
 	if "%APPVEYOR_REPO_TAG_NAME%"=="" (

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -2,11 +2,7 @@
 setlocal enableextensions enabledelayedexpansion
 	for %%a in (%ARCHITECTURES%) do (
 		set ARCH=%%a
-		rem if "!ARCH!"=="amd64" set DEPTS_ARCH=x64
-		rem if "!ARCH!"=="x86" set DEPTS_ARCH=x86
 
-		rem call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall" !ARCH!
-		rem call C:\projects\php-sdk\bin\phpsdk_setvars.bat
 		set SDK_RUNNER=%SDK_CACHE%\phpsdk-vc14-!ARCH!.bat
 		if not exist "!SDK_RUNNER!" (
 			echo "!SDK_RUNNER!" doesn't exist
@@ -17,19 +13,5 @@ setlocal enableextensions enabledelayedexpansion
 
 		if %errorlevel% neq 0 exit /b 3
 
-	)
-
-	if "%APPVEYOR_REPO_TAG_NAME%"=="" (
-		set APPVEYOR_REPO_TAG_NAME=%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT:~0,8%
-		for /f "delims=" %%l in (php_win32service.h) do (
-			if not "%%l"=="" (
-				set line=%%l
-				if "!line:~8,24!"=="PHP_WIN32SERVICE_VERSION" (
-					set APPVEYOR_REPO_TAG_NAME=!line:~34,-1!-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT:~0,8%
-				)
-			)
-		)
-
-		appveyor SetVariable -Name APPVEYOR_REPO_TAG_NAME -Value !APPVEYOR_REPO_TAG_NAME!
 	)
 endlocal

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -1,28 +1,45 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
+	if not exist "%SDK_CACHE%" (
+		echo Cloning remote SDK repository
+		git clone --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%" 2>&1
+	) else (
+		echo Fetching remote SDK repository
+		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin 2>&1
+		echo Checkout SDK repository branch
+		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" checkout --force %SDK_BRANCH%
+	)
+
 	echo git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
-	git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
+	git clone --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
 
 	xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\win32service\ /s /e /y /f
 
 	xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\artifacts\ /y /f
 	xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\artifacts\examples\ /y /f
 
-	cd %APPVEYOR_BUILD_FOLDER%\appveyor
-	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
-	7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
+	rem cd %APPVEYOR_BUILD_FOLDER%\appveyor
+	rem wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
+	rem 7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
 
 	for %%a in (%ARCHITECTURES%) do (
 		set ARCH=%%a
-		if "!ARCH!"=="amd64" set DEPTS_ARCH=x64
-		if "!ARCH!"=="x86" set DEPTS_ARCH=x86
+		rem if "!ARCH!"=="amd64" set DEPTS_ARCH=x64
+		rem if "!ARCH!"=="x86" set DEPTS_ARCH=x86
 
-		call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall" !ARCH!
-		call C:\projects\php-sdk\bin\phpsdk_setvars.bat
+		rem call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall" !ARCH!
+		rem call C:\projects\php-sdk\bin\phpsdk_setvars.bat
+		set SDK_RUNNER=%SDK_CACHE%\phpsdk-vc14-!ARCH!.bat
+		if not exist "!SDK_RUNNER!" (
+			echo "!SDK_RUNNER!" doesn't exist
+			exit /b 3
+		)
+
+		call !SDK_RUNNER!
 
 		cd %APPVEYOR_BUILD_FOLDER%\appveyor
-		wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!DEPTS_ARCH!.7z
-		7z x -y deps-%PHP_REL%-vc14-!DEPTS_ARCH!.7z -oC:\projects\php-src
+		wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
+		7z x -y deps-%PHP_REL%-vc14-!DEPTS_ARCH!.7z -o%CACHE_ROOT%
 
 		for %%z in (%ZTS_STATES%) do (
 			set ZTS_STATE=%%z
@@ -32,7 +49,12 @@ setlocal enableextensions enabledelayedexpansion
 			cd C:\projects\php-src
 
 			call buildconf.bat
-			call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=deps
+
+			if %errorlevel% neq 0 exit /b 3
+
+			call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%CACHE_ROOT%\deps
+
+			if %errorlevel% neq 0 exit /b 3
 
 			nmake
 

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -1,28 +1,5 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
-	if not exist "%SDK_CACHE%" (
-		echo Cloning remote SDK repository
-		echo git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
-		git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
-	) else (
-		echo Fetching remote SDK repository
-		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin
-		echo Checkout SDK repository branch
-		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" checkout --force %SDK_BRANCH%
-	)
-
-	echo git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
-	git clone -q --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
-
-	xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\win32service\ /s /e /y /f
-
-	xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\artifacts\ /y /f
-	xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\artifacts\examples\ /y /f
-
-	rem cd %APPVEYOR_BUILD_FOLDER%\appveyor
-	rem wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
-	rem 7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
-
 	for %%a in (%ARCHITECTURES%) do (
 		set ARCH=%%a
 		rem if "!ARCH!"=="amd64" set DEPTS_ARCH=x64

--- a/appveyor/build.cmd
+++ b/appveyor/build.cmd
@@ -38,6 +38,8 @@ setlocal enableextensions enabledelayedexpansion
 
 		call !SDK_RUNNER! -t %APPVEYOR_BUILD_FOLDER%\appveyor\build_task.cmd
 
+		if %errorlevel% neq 0 exit /b 3
+
 	)
 
 	if "%APPVEYOR_REPO_TAG_NAME%"=="" (

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -1,0 +1,36 @@
+@echo off
+setlocal enableextensions enabledelayedexpansion
+	cd %APPVEYOR_BUILD_FOLDER%\appveyor
+	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
+	7z x -y deps-%PHP_REL%-vc14-%ARCH%.7z -o%CACHE_ROOT%
+
+	for %%z in (%ZTS_STATES%) do (
+		set ZTS_STATE=%%z
+		if "!ZTS_STATE!"=="enable" set ZTS_SHORT=ts
+		if "!ZTS_STATE!"=="disable" set ZTS_SHORT=nts
+
+		cd C:\projects\php-src
+
+		call buildconf.bat
+
+		if %errorlevel% neq 0 exit /b 3
+
+		call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%CACHE_ROOT%\deps
+
+		if %errorlevel% neq 0 exit /b 3
+
+		nmake
+
+		if %errorlevel% neq 0 exit /b 3
+
+		nmake install
+
+		if %errorlevel% neq 0 exit /b 3
+
+		cd %APPVEYOR_BUILD_FOLDER%
+
+		if not exist build\ext\php_win32service.dll exit /b 3
+
+		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
+	)
+endlocal

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -30,12 +30,12 @@ setlocal enableextensions enabledelayedexpansion
 
 		if not exist "%APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll" exit /b 3
 
-		xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
-		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\examples\ /y /f
-		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
-		7z a php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\*
-		appveyor PushArtifact php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip -FileName php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
+		xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\examples\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\ /y /f
+		7z a php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\*
+		appveyor PushArtifact php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip -FileName php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip
 
-		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
+		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.dll
 	)
 endlocal

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -34,7 +34,7 @@ setlocal enableextensions enabledelayedexpansion
 		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\examples\ /y /f
 		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
 		7z a php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\*
-		appveyor PushArtifact appveyor php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
+		appveyor PushArtifact php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
 
 		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
 	)

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -30,6 +30,12 @@ setlocal enableextensions enabledelayedexpansion
 
 		if not exist "%APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll" exit /b 3
 
+		xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\examples\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
+		7z a php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\*
+		appveyor PushArtifact appveyor php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
+
 		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
 	)
 endlocal

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -1,8 +1,7 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
-	cd %APPVEYOR_BUILD_FOLDER%\appveyor
 	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
-	7z x -y %CACHE_ROOT%\deps-%PHP_REL%-vc14-%ARCH%.7z -o%CACHE_ROOT%
+	7z x -y %CACHE_ROOT%\deps-%PHP_REL%-vc14-%ARCH%.7z -oC:\projects\php-src
 
 	for %%z in (%ZTS_STATES%) do (
 		set ZTS_STATE=%%z
@@ -15,7 +14,7 @@ setlocal enableextensions enabledelayedexpansion
 
 		if %errorlevel% neq 0 exit /b 3
 
-		call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=%CACHE_ROOT%\deps
+		call configure.bat --disable-all --with-mp=auto --enable-cli --!ZTS_STATE!-zts --enable-win32service=shared --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\build\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\build --with-php-build=deps
 
 		if %errorlevel% neq 0 exit /b 3
 

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -2,7 +2,7 @@
 setlocal enableextensions enabledelayedexpansion
 	cd %APPVEYOR_BUILD_FOLDER%\appveyor
 	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
-	7z x -y deps-%PHP_REL%-vc14-%ARCH%.7z -o%CACHE_ROOT%
+	7z x -y %CACHE_ROOT%\deps-%PHP_REL%-vc14-%ARCH%.7z -o%CACHE_ROOT%
 
 	for %%z in (%ZTS_STATES%) do (
 		set ZTS_STATE=%%z

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -34,7 +34,7 @@ setlocal enableextensions enabledelayedexpansion
 		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\examples\ /y /f
 		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\ /y /f
 		7z a php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%\*
-		appveyor PushArtifact php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
+		appveyor PushArtifact php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip -FileName php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.zip
 
 		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
 	)

--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -9,7 +9,7 @@ setlocal enableextensions enabledelayedexpansion
 		if "!ZTS_STATE!"=="enable" set ZTS_SHORT=ts
 		if "!ZTS_STATE!"=="disable" set ZTS_SHORT=nts
 
-		cd C:\projects\php-src
+		cd /d C:\projects\php-src
 
 		call buildconf.bat
 
@@ -27,9 +27,9 @@ setlocal enableextensions enabledelayedexpansion
 
 		if %errorlevel% neq 0 exit /b 3
 
-		cd %APPVEYOR_BUILD_FOLDER%
+		cd /d %APPVEYOR_BUILD_FOLDER%
 
-		if not exist build\ext\php_win32service.dll exit /b 3
+		if not exist "%APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll" exit /b 3
 
 		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-vc14-!ZTS_SHORT!-%ARCH%.dll
 	)

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -25,4 +25,17 @@ setlocal enableextensions enabledelayedexpansion
 	rem wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
 	rem 7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
 
+	if "%APPVEYOR_REPO_TAG_NAME%"=="" (
+		set APPVEYOR_REPO_TAG_NAME=%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT:~0,8%
+		for /f "delims=" %%l in (php_win32service.h) do (
+			if not "%%l"=="" (
+				set line=%%l
+				if "!line:~8,24!"=="PHP_WIN32SERVICE_VERSION" (
+					set APPVEYOR_REPO_TAG_NAME=!line:~34,-1!-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT:~0,8%
+				)
+			)
+		)
+
+		appveyor SetVariable -Name APPVEYOR_REPO_TAG_NAME -Value !APPVEYOR_REPO_TAG_NAME!
+	)
 endlocal

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -1,0 +1,28 @@
+@echo off
+setlocal enableextensions enabledelayedexpansion
+	cinst wget
+	mkdir C:\projects\win32service\build
+	if not exist "%SDK_CACHE%" (
+		echo Cloning remote SDK repository
+		echo git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
+		git clone -q --depth=1 --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
+	) else (
+		echo Fetching remote SDK repository
+		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin
+		echo Checkout SDK repository branch
+		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" checkout --force %SDK_BRANCH%
+	)
+
+	echo git clone -q --depth=1 --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
+	git clone -q --depth=1 --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src
+
+	xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\win32service\ /s /e /y /f
+
+	xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\artifacts\ /y /f
+	xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\artifacts\examples\ /y /f
+
+	rem cd %APPVEYOR_BUILD_FOLDER%\appveyor
+	rem wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
+	rem 7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
+
+endlocal

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -21,10 +21,6 @@ setlocal enableextensions enabledelayedexpansion
 	xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\artifacts\ /y /f
 	xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\artifacts\examples\ /y /f
 
-	rem cd %APPVEYOR_BUILD_FOLDER%\appveyor
-	rem wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
-	rem 7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
-
 	if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 		set APPVEYOR_REPO_TAG_NAME=%APPVEYOR_REPO_BRANCH%-%APPVEYOR_REPO_COMMIT:~0,8%
 		for /f "delims=" %%l in (php_win32service.h) do (


### PR DESCRIPTION
Upgrading build script to use the new php-sdk OSTC/php-sdk-binary-tools #12
* YAML AppVeyor: Simplified, added new environment variables.
* Install Script (install.cmd): New, prepare the build environment
* Build Script (build.cmd): Simplified, sets the environment variables for each Architecture.
* Build Task Script (build_task.cmd): New, build the TS and NTS versions for each Architecture.
* Added new artifacts, each binary of the extensión, LICENSE file and examples are packaged as separate zip for each version (PHP release, Architecture and TS/NTS).