### PR TITLE
Update build_task to use %PHP_SDK_ARCH% instead of %ARCH%

### DIFF
--- a/appveyor/build_task.cmd
+++ b/appveyor/build_task.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal enableextensions enabledelayedexpansion
-	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-!ARCH!.7z -P %CACHE_ROOT%
-	7z x -y %CACHE_ROOT%\deps-%PHP_REL%-vc14-%ARCH%.7z -oC:\projects\php-src
+	wget -N --progress=bar:force:noscroll http://windows.php.net/downloads/php-sdk/deps-%PHP_REL%-vc14-%PHP_SDK_ARCH%.7z -P %CACHE_ROOT%
+	7z x -y %CACHE_ROOT%\deps-%PHP_REL%-vc14-%PHP_SDK_ARCH%.7z -oC:\projects\php-src
 
 	for %%z in (%ZTS_STATES%) do (
 		set ZTS_STATE=%%z
@@ -30,12 +30,12 @@ setlocal enableextensions enabledelayedexpansion
 
 		if not exist "%APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll" exit /b 3
 
-		xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\ /y /f
-		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\examples\ /y /f
-		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\ /y /f
-		7z a php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%\*
-		appveyor PushArtifact php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip -FileName php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.zip
+		xcopy %APPVEYOR_BUILD_FOLDER%\LICENSE %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\examples %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%\examples\ /y /f
+		xcopy %APPVEYOR_BUILD_FOLDER%\build\ext\php_win32service.dll %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%\ /y /f
+		7z a php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%.zip %APPVEYOR_BUILD_FOLDER%\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%\*
+		appveyor PushArtifact php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%.zip -FileName php_win32service-%APPVEYOR_REPO_TAG_NAME%-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%.zip
 
-		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%ARCH%.dll
+		move build\ext\php_win32service.dll artifacts\php_win32service-%PHP_REL%-!ZTS_SHORT!-vc14-%PHP_SDK_ARCH%.dll
 	)
 endlocal

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -2,7 +2,7 @@
 setlocal enableextensions enabledelayedexpansion
 	cinst wget
 	mkdir C:\projects\win32service\build
-	if not exist "%SDK_CACHE%" (
+	if not exist "%SDK_CACHE%\.git" (
 		echo Cloning remote SDK repository
 		echo git clone -q --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
 		git clone -q --depth=1 --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"

--- a/appveyor/install.cmd
+++ b/appveyor/install.cmd
@@ -11,6 +11,10 @@ setlocal enableextensions enabledelayedexpansion
 		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" fetch --prune origin
 		echo Checkout SDK repository branch
 		git --git-dir="%SDK_CACHE%\.git" --work-tree="%SDK_CACHE%" checkout --force %SDK_BRANCH%
+		if %errorlevel% neq 0 (
+			rmdir /s /q %SDK_CACHE%
+			git clone -q --depth=1 --branch %SDK_BRANCH% %SDK_REMOTE% "%SDK_CACHE%"
+		)
 	)
 
 	echo git clone -q --depth=1 --branch=PHP-%PHP_REL% https://github.com/php/php-src C:\projects\php-src


### PR DESCRIPTION
Update build_task to use %PHP_SDK_ARCH% instead of %ARCH%

Update install to check %SDK_CACHE%\.git instead of %SDK_CACHE%

Changes required by [PHP_SDK](https://github.com/OSTC/php-sdk-binary-tools) updates.