### PR TITLE
Fix artifact name for 8.4 branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,7 @@ jobs:
           if ('8.1' -eq '${{matrix.php-rel}}') { $artifact_name = $artifact_name + '-vs16' }
           if ('8.2' -eq '${{matrix.php-rel}}') { $artifact_name = $artifact_name + '-vs16' }
           if ('8.3' -eq '${{matrix.php-rel}}') { $artifact_name = $artifact_name + '-vs16' }
+          if ('8.4' -eq '${{matrix.php-rel}}') { $artifact_name = $artifact_name + '-vs17' }
 
           if ('x64' -eq '${{matrix.platform}}') { $artifact_name = $artifact_name + '-x64' }
           if ('x86' -eq '${{matrix.platform}}') { $artifact_name = $artifact_name + '-x86' }


### PR DESCRIPTION
Artifact name for 8.4 branch is fixed to ```php_win32service-1.0.2-8.4-ts-vs17-x64```. Reference ```vs17``` is added.
